### PR TITLE
Add FastAPI subscription API

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package containing API modules."""

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import asyncpg
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://localhost/postgres")
+
+app = FastAPI()
+_pool: Optional[asyncpg.Pool] = None
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    """Create an asyncpg connection pool on startup."""
+    global _pool
+    _pool = await asyncpg.create_pool(DATABASE_URL)
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    """Close the asyncpg connection pool on shutdown."""
+    if _pool is not None:
+        await _pool.close()
+
+
+class Subscription(BaseModel):
+    discord_id: int
+    plan: str
+
+
+@app.get("/api/subscription/{discord_id}")
+async def get_subscription(discord_id: int) -> dict:
+    if _pool is None:
+        raise HTTPException(status_code=500, detail="Database pool not initialised")
+    async with _pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT discord_id, plan FROM subscriptions WHERE discord_id=$1",
+            discord_id,
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="Subscription not found")
+        return {"discord_id": row["discord_id"], "plan": row["plan"]}
+
+
+@app.post("/api/subscription")
+async def create_subscription(sub: Subscription) -> dict:
+    if _pool is None:
+        raise HTTPException(status_code=500, detail="Database pool not initialised")
+    async with _pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO subscriptions (discord_id, plan)
+            VALUES ($1, $2)
+            ON CONFLICT (discord_id) DO UPDATE SET plan = EXCLUDED.plan
+            RETURNING discord_id, plan
+            """,
+            sub.discord_id,
+            sub.plan,
+        )
+        return {"discord_id": row["discord_id"], "plan": row["plan"]}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("backend.api:app", host="0.0.0.0", port=8000, reload=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,14 @@ aiohappyeyeballs==2.6.1
 aiohttp==3.12.15
 aiosignal==1.4.0
 anyio==4.10.0
+asyncpg==0.29.0
 attrs==25.3.0
 certifi==2025.8.3
 charset-normalizer==3.4.3
 deepl==1.22.0
 discord==2.3.2
 discord.py==2.6.2
+fastapi==0.110.0
 frozenlist==1.7.0
 git-filter-repo==2.47.0
 h11==0.16.0
@@ -22,5 +24,6 @@ requests==2.32.5
 sniffio==1.3.1
 typing_extensions==4.15.0
 urllib3==2.5.0
+uvicorn==0.28.0
 watchdog==6.0.0
 yarl==1.20.1


### PR DESCRIPTION
## Summary
- add FastAPI app with asyncpg connection pool and subscription endpoints
- include FastAPI, asyncpg and uvicorn in requirements

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c15ffa02788327b779034f6aa690e7