### PR TITLE
Add Discord login, Stripe checkout, and session status UI

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -4,12 +4,28 @@ import os
 from typing import Optional
 
 import asyncpg
-from fastapi import FastAPI, HTTPException
+import requests
+import stripe
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
+from starlette.middleware.sessions import SessionMiddleware
+from urllib.parse import urlencode
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://localhost/postgres")
+DISCORD_CLIENT_ID = os.getenv("DISCORD_CLIENT_ID")
+DISCORD_CLIENT_SECRET = os.getenv("DISCORD_CLIENT_SECRET")
+DISCORD_REDIRECT_URI = os.getenv(
+    "DISCORD_REDIRECT_URI", "http://localhost:8000/auth/discord/callback"
+)
+STRIPE_SECRET_KEY = os.getenv("STRIPE_SECRET_KEY", "")
+STRIPE_PRICE_ID = os.getenv("STRIPE_PRICE_ID", "")
+STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET", "")
+
+stripe.api_key = STRIPE_SECRET_KEY
 
 app = FastAPI()
+app.add_middleware(SessionMiddleware, secret_key=os.getenv("SESSION_SECRET", "dev"))
 _pool: Optional[asyncpg.Pool] = None
 
 
@@ -62,6 +78,102 @@ async def create_subscription(sub: Subscription) -> dict:
             sub.plan,
         )
         return {"discord_id": row["discord_id"], "plan": row["plan"]}
+
+
+@app.get("/auth/discord")
+async def auth_discord() -> RedirectResponse:
+    if not DISCORD_CLIENT_ID:
+        raise HTTPException(status_code=500, detail="Missing Discord OAuth configuration")
+    params = {
+        "client_id": DISCORD_CLIENT_ID,
+        "redirect_uri": DISCORD_REDIRECT_URI,
+        "response_type": "code",
+        "scope": "identify",
+    }
+    url = "https://discord.com/api/oauth2/authorize?" + urlencode(params)
+    return RedirectResponse(url)
+
+
+@app.get("/auth/discord/callback")
+async def auth_discord_callback(request: Request, code: str):
+    data = {
+        "client_id": DISCORD_CLIENT_ID,
+        "client_secret": DISCORD_CLIENT_SECRET,
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": DISCORD_REDIRECT_URI,
+    }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    token_res = requests.post("https://discord.com/api/oauth2/token", data=data, headers=headers)
+    token_res.raise_for_status()
+    access_token = token_res.json()["access_token"]
+    user_res = requests.get(
+        "https://discord.com/api/users/@me",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    user_res.raise_for_status()
+    user = user_res.json()
+    request.session["discord_id"] = int(user["id"])
+    request.session["username"] = user["username"]
+    return RedirectResponse("/")
+
+
+@app.get("/session")
+async def session_info(request: Request) -> dict:
+    if "discord_id" not in request.session:
+        return {"authenticated": False}
+    return {
+        "authenticated": True,
+        "discord_id": request.session["discord_id"],
+        "username": request.session["username"],
+    }
+
+
+@app.post("/checkout")
+async def checkout(request: Request) -> dict:
+    if "discord_id" not in request.session:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    try:
+        session = stripe.checkout.Session.create(
+            success_url=os.getenv("STRIPE_SUCCESS_URL", "http://localhost:8000/"),
+            cancel_url=os.getenv("STRIPE_CANCEL_URL", "http://localhost:8000/"),
+            mode="subscription",
+            line_items=[{"price": STRIPE_PRICE_ID, "quantity": 1}],
+            metadata={
+                "discord_id": str(request.session["discord_id"]),
+                "plan": "default",
+            },
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return {"id": session.id, "url": session.url}
+
+
+@app.post("/stripe/webhook")
+async def stripe_webhook(request: Request) -> dict:
+    payload = (await request.body()).decode("utf-8")
+    sig_header = request.headers.get("stripe-signature")
+    try:
+        event = stripe.Webhook.construct_event(payload, sig_header, STRIPE_WEBHOOK_SECRET)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid payload")
+    if event["type"] == "checkout.session.completed":
+        session = event["data"]["object"]
+        discord_id = int(session["metadata"].get("discord_id", 0))
+        plan = session["metadata"].get("plan", "default")
+        if _pool is None:
+            raise HTTPException(status_code=500, detail="Database pool not initialised")
+        async with _pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO subscriptions (discord_id, plan)
+                VALUES ($1, $2)
+                ON CONFLICT (discord_id) DO UPDATE SET plan = EXCLUDED.plan
+                """,
+                discord_id,
+                plan,
+            )
+    return {"status": "success"}
 
 
 if __name__ == "__main__":

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,7 +81,13 @@ a:hover {
     <h1>📚 Catcord Documentation</h1>
     <p class="lead">Guides and manuals for using and administering Catcord.</p>
 
-    
+    <div id="auth">
+      <button id="login">Login with Discord</button>
+      <button id="subscribe">Subscribe</button>
+      <p id="status"></p>
+    </div>
+
+
     <div class="card-grid">
       <div class="card">
         <h3>Admin Guide</h3>
@@ -106,4 +112,36 @@ a:hover {
     </div>
   </div>
 </body>
+<script>
+async function loadStatus() {
+  const status = document.getElementById('status');
+  try {
+    const res = await fetch('/session');
+    const data = await res.json();
+    if (!data.authenticated) {
+      status.textContent = 'Not logged in.';
+      return;
+    }
+    status.textContent = `Logged in as ${data.username}`;
+    const subRes = await fetch(`/api/subscription/${data.discord_id}`);
+    if (subRes.ok) {
+      const sub = await subRes.json();
+      status.textContent += ` – Plan: ${sub.plan}`;
+    }
+  } catch (e) {
+    status.textContent = 'Error loading session.';
+  }
+}
+document.getElementById('login').onclick = () => {
+  window.location.href = '/auth/discord';
+};
+document.getElementById('subscribe').onclick = async () => {
+  const res = await fetch('/checkout', {method: 'POST'});
+  const data = await res.json();
+  if (data.url) {
+    window.location.href = data.url;
+  }
+};
+loadStatus();
+</script>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ propcache==0.3.2
 python-dotenv==1.1.1
 PyYAML==6.0.2
 requests==2.32.5
+stripe==11.1.0
 sniffio==1.3.1
 typing_extensions==4.15.0
 urllib3==2.5.0


### PR DESCRIPTION
## Summary
- implement Discord OAuth2 login endpoints and session handling
- add Stripe checkout session creation and webhook to update subscriptions
- update docs site with login/subscribe buttons that show session status

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1678e80348327ab9a14db8b7a9e39