### PR TITLE
Allow time-based reminders without interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,13 @@ Use `/reminder` commands to schedule repeating messages.
 **Syntax**
 
 ```
-/reminder add name:<id> interval:<number> unit:<minutes|hours|days> channel:<#channel> message:<text> [weekday:<day>] [time:<HH:MM>]
+/reminder add name:<id> channel:<#channel> message:<text> [interval:<number> unit:<minutes|hours|days>] [weekday:<day>] [time:<HH:MM>]
 ```
 
 **Examples**
 
-- `/reminder add name:backup interval:1 unit:days channel:#general message:"Run backup" time:02:00`
+- `/reminder add name:backup channel:#general message:"Run backup" time:02:00`
+- `/reminder add name:standup channel:#dev message:"Daily standup" interval:1 unit:days time:09:00`
 - `/reminder remove name:backup`
 - `/reminder list`
 

--- a/docs/CATCORD_ADMIN_GUIDE.html
+++ b/docs/CATCORD_ADMIN_GUIDE.html
@@ -35,10 +35,11 @@
 <h2>Reminders</h2>
 <p>Schedule repeating messages using <code>/reminder</code> commands.</p>
 <h3>Syntax</h3>
-<pre>/reminder add name:&lt;id&gt; interval:&lt;number&gt; unit:&lt;minutes|hours|days&gt; channel:&lt;#channel&gt; message:&lt;text&gt; [weekday:&lt;day&gt;] [time:&lt;HH:MM&gt;]</pre>
+<pre>/reminder add name:&lt;id&gt; channel:&lt;#channel&gt; message:&lt;text&gt; [interval:&lt;number&gt; unit:&lt;minutes|hours|days&gt;] [weekday:&lt;day&gt;] [time:&lt;HH:MM&gt;]</pre>
 <h3>Examples</h3>
 <ul>
-<li><code>/reminder add name:backup interval:1 unit:days channel:#general message:"Run backup" time:02:00</code></li>
+<li><code>/reminder add name:backup channel:#general message:"Run backup" time:02:00</code></li>
+<li><code>/reminder add name:standup channel:#dev message:"Daily standup" interval:1 unit:days time:09:00</code></li>
 <li><code>/reminder remove name:backup</code></li>
 <li><code>/reminder list</code></li>
 </ul>

--- a/tests/test_guild_token.py
+++ b/tests/test_guild_token.py
@@ -1,6 +1,10 @@
 import os
 import importlib
 import unittest
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 
 class GuildTokenTest(unittest.TestCase):

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -1,0 +1,37 @@
+import pathlib
+import importlib.util
+import unittest
+
+
+spec = importlib.util.spec_from_file_location(
+    "reminder", pathlib.Path(__file__).resolve().parents[1] / "cogs" / "reminder.py"
+)
+reminder = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(reminder)
+Reminder = reminder.Reminder
+
+
+class ResolveIntervalTest(unittest.TestCase):
+    def test_defaults_daily(self):
+        interval, unit = Reminder._resolve_interval(None, None, None, True)
+        self.assertEqual(interval, 1)
+        self.assertEqual(unit, "days")
+
+    def test_defaults_weekly(self):
+        interval, unit = Reminder._resolve_interval(None, None, 2, False)
+        self.assertEqual(interval, 7)
+        self.assertEqual(unit, "days")
+
+    def test_requires_both_interval_and_unit(self):
+        with self.assertRaises(ValueError):
+            Reminder._resolve_interval(1, None, None, False)
+        with self.assertRaises(ValueError):
+            Reminder._resolve_interval(None, "days", None, False)
+
+    def test_requires_info(self):
+        with self.assertRaises(ValueError):
+            Reminder._resolve_interval(None, None, None, False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Support reminders triggered by time or weekday without needing explicit interval/unit
- Document optional interval usage in README and admin guide
- Test reminder interval defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2e11001648327b49f16b983623a09