### PR TITLE
Improve reminder scheduling flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,17 +133,18 @@ Use `/reminder` commands to schedule repeating messages.
 **Syntax**
 
 ```
-/reminder add name:<id> channel:<#channel> message:<text> [interval:<number> unit:<minutes|hours|days>] [weekday:<day>] [time:<HH:MM>]
+/reminder add name:<id> channel:<#channel> message:<text> [interval:<number> unit:<minutes|hours|days>] [weekday:<day>] [time:<HH:MM>] [once:true]
 ```
 
 **Examples**
 
 - `/reminder add name:backup channel:#general message:"Run backup" time:02:00`
 - `/reminder add name:standup channel:#dev message:"Daily standup" interval:1 unit:days time:09:00`
+- `/reminder add name:launch channel:#ops message:"Launch prep" time:13:00 once:true`
 - `/reminder remove name:backup`
 - `/reminder list`
 
-Reminders persist across bot restarts and are stored per guild in `./data/reminder/<guild_id>.json`.
+Reminders persist across bot restarts and are stored per guild in `./data/reminder/<guild_id>.json`. When a time is provided, reminders fire on the minute (UTC). Setting only a `time` schedules a daily reminder, and enabling `once:true` creates a one-time reminder that clears itself after firing.
 
 *Permissions*: members need **Use Application Commands** to create or remove reminders, and the bot must have **Send Messages** in the target channel.
 

--- a/cogs/reminder.py
+++ b/cogs/reminder.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from pathlib import Path
 
@@ -43,6 +44,7 @@ class Reminder(commands.Cog):
                     "channel_id": info["channel_id"],
                     "message": info["message"],
                     "last": info["last"],
+                    "one_time": info["one_time"],
                 }
                 for name, info in rems.items()
             }
@@ -72,6 +74,7 @@ class Reminder(commands.Cog):
                     info.get("hour"),
                     info.get("minute"),
                     info.get("last"),
+                    info.get("one_time", False),
                     save=False,
                 )
 
@@ -93,13 +96,13 @@ class Reminder(commands.Cog):
         hour: int | None = None,
         minute: int | None = None,
         last: float | None = None,
+        one_time: bool = False,
         save: bool = True,
     ) -> None:
         seconds_per_unit = {"minutes": 60, "hours": 3600, "days": 86400}
         interval_seconds = interval * seconds_per_unit.get(unit, 1)
 
         async def send_reminder():
-            await self.bot.wait_until_ready()
             now = time.time()
             info = self.reminders[guild_id][name]
             if now - info["last"] < interval_seconds:
@@ -161,10 +164,17 @@ class Reminder(commands.Cog):
                         print(f"⚠️ Reminder LangRelay integration failed: {e}")
 
                 info["last"] = now
+
+                if info["one_time"]:
+                    loop_obj = info["task"]
+                    loop_obj.stop()
+                    self.bot.loop.call_soon(loop_obj.cancel)
+                    del self.reminders[guild_id][name]
+                    if not self.reminders[guild_id]:
+                        del self.reminders[guild_id]
                 self.save_reminders()
 
         loop = tasks.loop(seconds=60)(send_reminder)
-        loop.start()
         default_last = (
             0.0 if any(v is not None for v in (weekday, hour, minute)) else time.time()
         )
@@ -178,33 +188,32 @@ class Reminder(commands.Cog):
             "message": message,
             "task": loop,
             "last": last if last is not None else default_last,
+            "one_time": one_time,
         }
+        align_to_minute = minute is not None or hour is not None
+
+        async def starter():
+            await self.bot.wait_until_ready()
+            if align_to_minute:
+                delay = self._seconds_until_next_minute()
+                if delay:
+                    await asyncio.sleep(delay)
+            loop.start()
+
+        self.bot.loop.create_task(starter())
         if save:
             self.save_reminders()
 
     @staticmethod
-    def _resolve_interval(
-        interval: int | None,
-        unit: str | None,
-        weekday: int | None,
-        has_time: bool,
-    ) -> tuple[int, str]:
-        """Determine final interval/unit values.
+    def _seconds_until_next_minute(now: datetime | None = None) -> float:
+        """Seconds until the next minute boundary from ``now`` (UTC)."""
 
-        If both ``interval`` and ``unit`` are provided, they are used directly.
-        If neither is provided but ``weekday`` or ``has_time`` is given, sensible
-        defaults are returned (weekly or daily).  Otherwise a ``ValueError`` is
-        raised.
-        """
-
-        if interval is None and unit is None:
-            if weekday is not None or has_time:
-                # default to weekly when weekday specified, otherwise daily
-                return (7 if weekday is not None else 1, "days")
-            raise ValueError("interval and unit required without time/weekday")
-        if interval is None or unit is None:
-            raise ValueError("interval and unit must be given together")
-        return (interval, unit)
+        now = now or datetime.utcnow()
+        current_minute = now.replace(second=0, microsecond=0)
+        if now == current_minute:
+            return 0.0
+        next_minute = current_minute + timedelta(minutes=1)
+        return (next_minute - now).total_seconds()
 
     @staticmethod
     def _resolve_interval(
@@ -239,6 +248,7 @@ class Reminder(commands.Cog):
         unit="Optional interval unit",
         weekday="Optional day of week",
         time="Optional time of day HH:MM (UTC)",
+        once="Send only once when triggered",
     )
     @app_commands.choices(
         unit=[
@@ -266,6 +276,7 @@ class Reminder(commands.Cog):
         unit: app_commands.Choice[str] | None = None,
         weekday: app_commands.Choice[int] | None = None,
         time: str | None = None,
+        once: bool = False,
     ) -> None:
         if not interaction.guild:
             await interaction.response.send_message("Guild only.", ephemeral=True)
@@ -309,6 +320,7 @@ class Reminder(commands.Cog):
             weekday.value if weekday else None,
             hour,
             minute,
+            one_time=once,
         )
         await interaction.response.send_message(
             f"Reminder `{name}` added.", ephemeral=True
@@ -359,13 +371,30 @@ class Reminder(commands.Cog):
         for name, info in guild_rems.items():
             channel = self.bot.get_channel(info["channel_id"])
             ch = channel.mention if channel else f"#{info['channel_id']}"
-            interval = f"{info['interval']} {info['unit']}"
-            if info["weekday"] is not None:
-                days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
-                interval += f" on {days[info['weekday']]}"
-            if info["hour"] is not None and info["minute"] is not None:
-                interval += f" at {info['hour']:02d}:{info['minute']:02d}"
-            lines.append(f"`{name}` every {interval} in {ch}: {info['message']}")
+            days = [
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday",
+                "Sunday",
+            ]
+            if info["one_time"]:
+                schedule = "once"
+                if info["weekday"] is not None:
+                    schedule += f" on {days[info['weekday']]}"
+                if info["hour"] is not None and info["minute"] is not None:
+                    schedule += f" at {info['hour']:02d}:{info['minute']:02d}"
+                elif info["interval"] and info["unit"]:
+                    schedule += f" after {info['interval']} {info['unit']}"
+            else:
+                schedule = f"every {info['interval']} {info['unit']}"
+                if info["weekday"] is not None:
+                    schedule += f" on {days[info['weekday']]}"
+                if info["hour"] is not None and info["minute"] is not None:
+                    schedule += f" at {info['hour']:02d}:{info['minute']:02d}"
+            lines.append(f"`{name}` {schedule} in {ch}: {info['message']}")
         await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
 

--- a/docs/CATCORD_ADMIN_GUIDE.html
+++ b/docs/CATCORD_ADMIN_GUIDE.html
@@ -65,15 +65,16 @@
 <h2>Reminders</h2>
 <p>Schedule repeating messages using <code>/reminder</code> commands.</p>
 <h3>Syntax</h3>
-<pre>/reminder add name:&lt;id&gt; channel:&lt;#channel&gt; message:&lt;text&gt; [interval:&lt;number&gt; unit:&lt;minutes|hours|days&gt;] [weekday:&lt;day&gt;] [time:&lt;HH:MM&gt;]</pre>
+<pre>/reminder add name:&lt;id&gt; channel:&lt;#channel&gt; message:&lt;text&gt; [interval:&lt;number&gt; unit:&lt;minutes|hours|days&gt;] [weekday:&lt;day&gt;] [time:&lt;HH:MM&gt;] [once:true]</pre>
 <h3>Examples</h3>
 <ul>
 <li><code>/reminder add name:backup channel:#general message:"Run backup" time:02:00</code></li>
 <li><code>/reminder add name:standup channel:#dev message:"Daily standup" interval:1 unit:days time:09:00</code></li>
+<li><code>/reminder add name:launch channel:#ops message:"Launch prep" time:13:00 once:true</code></li>
 <li><code>/reminder remove name:backup</code></li>
 <li><code>/reminder list</code></li>
 </ul>
-<p>Reminders persist across bot restarts and are stored per guild in <code>./data/reminder/&lt;guild_id&gt;.json</code>.</p>
+<p>Reminders persist across bot restarts and are stored per guild in <code>./data/reminder/&lt;guild_id&gt;.json</code>. When a time is provided, reminders fire on the minute (UTC). Supplying only a time schedules a daily reminder, and adding <code>once:true</code> creates a one-time reminder that deletes itself after sending.</p>
 <p><em>Permissions</em>: members need <strong>Use Application Commands</strong> to create or remove reminders, and the bot must have <strong>Send Messages</strong> in the target channel.</p>
 </section>
 

--- a/docs/CATCORD_ADMIN_QUICKSTART.html
+++ b/docs/CATCORD_ADMIN_QUICKSTART.html
@@ -74,6 +74,7 @@
 <div>
 <h2>8) Schedule Reminders</h2>
 <pre>/reminder add name:backup channel:#general message:"Run backup" time:02:00
+/reminder add name:launch channel:#ops message:"Launch prep" time:13:00 once:true
 /reminder list
 /reminder remove name:backup</pre>
 </div>

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -1,5 +1,6 @@
-import pathlib
+import datetime
 import importlib.util
+import pathlib
 import unittest
 
 
@@ -31,6 +32,20 @@ class ResolveIntervalTest(unittest.TestCase):
     def test_requires_info(self):
         with self.assertRaises(ValueError):
             Reminder._resolve_interval(None, None, None, False)
+
+
+class SecondsUntilNextMinuteTest(unittest.TestCase):
+    def test_exact_boundary(self):
+        now = datetime.datetime(2024, 1, 1, 12, 0, 0)
+        self.assertEqual(Reminder._seconds_until_next_minute(now), 0.0)
+
+    def test_half_minute(self):
+        now = datetime.datetime(2024, 1, 1, 12, 0, 30)
+        self.assertEqual(Reminder._seconds_until_next_minute(now), 30)
+
+    def test_fractional_second(self):
+        now = datetime.datetime(2024, 1, 1, 12, 0, 59, 500000)
+        self.assertAlmostEqual(Reminder._seconds_until_next_minute(now), 0.5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- track and persist a `one_time` flag on reminders so one-off messages remove themselves after firing
- align time-based reminder loops to the top of the minute via a shared helper and start-up delay
- expose the new `once` option in the slash command/list output and update the reminder documentation
- add unit coverage for the minute-alignment helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc80c2e2848327bf75831843db1ce4