### PR TITLE
Add embed headlines and multiline support to reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,18 +133,19 @@ Use `/reminder` commands to schedule repeating messages.
 **Syntax**
 
 ```
-/reminder add name:<id> channel:<#channel> message:<text> [interval:<number> unit:<minutes|hours|days>] [weekday:<day>] [time:<HH:MM>] [once:true]
+/reminder add name:<id> channel:<#channel> message:<text> [headline:<title>] [interval:<number> unit:<minutes|hours|days>] [weekday:<day>] [time:<HH:MM>] [once:true]
 ```
 
 **Examples**
 
 - `/reminder add name:backup channel:#general message:"Run backup" time:02:00`
 - `/reminder add name:standup channel:#dev message:"Daily standup" interval:1 unit:days time:09:00`
+- `/reminder add name:colony channel:#ops message:"Territory Development\\n-Building Power\\n-Fortification Power" headline:"Colony Action" interval:1 unit:days`
 - `/reminder add name:launch channel:#ops message:"Launch prep" time:13:00 once:true`
 - `/reminder remove name:backup`
 - `/reminder list`
 
-Reminders persist across bot restarts and are stored per guild in `./data/reminder/<guild_id>.json`. When a time is provided, reminders fire on the minute (UTC). Setting only a `time` schedules a daily reminder, and enabling `once:true` creates a one-time reminder that clears itself after firing.
+Reminders persist across bot restarts and are stored per guild in `./data/reminder/<guild_id>.json`. When a time is provided, reminders fire on the minute (UTC). Setting only a `time` schedules a daily reminder, and enabling `once:true` creates a one-time reminder that clears itself after firing. Provide an optional `headline` to send the reminder inside an embed, and include `\n` in the message text to create multi-line reminders.
 
 *Permissions*: members need **Use Application Commands** to create or remove reminders, and the bot must have **Send Messages** in the target channel.
 

--- a/docs/CATCORD_ADMIN_GUIDE.html
+++ b/docs/CATCORD_ADMIN_GUIDE.html
@@ -65,16 +65,17 @@
 <h2>Reminders</h2>
 <p>Schedule repeating messages using <code>/reminder</code> commands.</p>
 <h3>Syntax</h3>
-<pre>/reminder add name:&lt;id&gt; channel:&lt;#channel&gt; message:&lt;text&gt; [interval:&lt;number&gt; unit:&lt;minutes|hours|days&gt;] [weekday:&lt;day&gt;] [time:&lt;HH:MM&gt;] [once:true]</pre>
+<pre>/reminder add name:&lt;id&gt; channel:&lt;#channel&gt; message:&lt;text&gt; [headline:&lt;title&gt;] [interval:&lt;number&gt; unit:&lt;minutes|hours|days&gt;] [weekday:&lt;day&gt;] [time:&lt;HH:MM&gt;] [once:true]</pre>
 <h3>Examples</h3>
 <ul>
 <li><code>/reminder add name:backup channel:#general message:"Run backup" time:02:00</code></li>
 <li><code>/reminder add name:standup channel:#dev message:"Daily standup" interval:1 unit:days time:09:00</code></li>
+<li><code>/reminder add name:colony channel:#ops message:"Territory Development\n-Building Power\n-Fortification Power" headline:"Colony Action" interval:1 unit:days</code></li>
 <li><code>/reminder add name:launch channel:#ops message:"Launch prep" time:13:00 once:true</code></li>
 <li><code>/reminder remove name:backup</code></li>
 <li><code>/reminder list</code></li>
 </ul>
-<p>Reminders persist across bot restarts and are stored per guild in <code>./data/reminder/&lt;guild_id&gt;.json</code>. When a time is provided, reminders fire on the minute (UTC). Supplying only a time schedules a daily reminder, and adding <code>once:true</code> creates a one-time reminder that deletes itself after sending.</p>
+<p>Reminders persist across bot restarts and are stored per guild in <code>./data/reminder/&lt;guild_id&gt;.json</code>. When a time is provided, reminders fire on the minute (UTC). Supplying only a time schedules a daily reminder, and adding <code>once:true</code> creates a one-time reminder that deletes itself after sending. Provide an optional <code>headline</code> to place the reminder inside an embed, and include <code>\n</code> in the message text for multi-line reminders.</p>
 <p><em>Permissions</em>: members need <strong>Use Application Commands</strong> to create or remove reminders, and the bot must have <strong>Send Messages</strong> in the target channel.</p>
 </section>
 

--- a/docs/CATCORD_ADMIN_QUICKSTART.html
+++ b/docs/CATCORD_ADMIN_QUICKSTART.html
@@ -74,6 +74,7 @@
 <div>
 <h2>8) Schedule Reminders</h2>
 <pre>/reminder add name:backup channel:#general message:"Run backup" time:02:00
+/reminder add name:colony channel:#ops message:"Territory Development\n-Building Power\n-Fortification Power" headline:"Colony Action" interval:1 unit:days
 /reminder add name:launch channel:#ops message:"Launch prep" time:13:00 once:true
 /reminder list
 /reminder remove name:backup</pre>


### PR DESCRIPTION
## Summary
- allow reminders to persist optional embed headlines and convert escaped newlines when sending
- update reminder listings and LangRelay mirroring to respect embed headlines
- document the new headline option and multiline message usage in the admin guides

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc864335448327a5139cfcaa015e1f