### PR TITLE
Add guild-level reminder enable toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,11 @@ Use `/reminder` commands to schedule repeating messages.
 - `/reminder add name:launch channel:#ops message:"Launch prep" time:13:00 once:true`
 - `/reminder remove name:backup`
 - `/reminder list`
+- `/reminder toggle enabled:false`
 
 Reminders persist across bot restarts and are stored per guild in `./data/reminder/<guild_id>.json`. When a time is provided, reminders fire on the minute (UTC). Setting only a `time` schedules a daily reminder, and enabling `once:true` creates a one-time reminder that clears itself after firing. Provide an optional `headline` to send the reminder inside an embed, and include `\n` in the message text to create multi-line reminders.
+
+Use `/reminder toggle enabled:false` to pause reminder delivery for the entire server while keeping the schedules saved. Re-enable deliveries with `/reminder toggle enabled:true`.
 
 *Permissions*: members need **Use Application Commands** to create or remove reminders, and the bot must have **Send Messages** in the target channel.
 

--- a/docs/CATCORD_ADMIN_GUIDE.html
+++ b/docs/CATCORD_ADMIN_GUIDE.html
@@ -74,8 +74,10 @@
 <li><code>/reminder add name:launch channel:#ops message:"Launch prep" time:13:00 once:true</code></li>
 <li><code>/reminder remove name:backup</code></li>
 <li><code>/reminder list</code></li>
+<li><code>/reminder toggle enabled:false</code></li>
 </ul>
 <p>Reminders persist across bot restarts and are stored per guild in <code>./data/reminder/&lt;guild_id&gt;.json</code>. When a time is provided, reminders fire on the minute (UTC). Supplying only a time schedules a daily reminder, and adding <code>once:true</code> creates a one-time reminder that deletes itself after sending. Provide an optional <code>headline</code> to place the reminder inside an embed, and include <code>\n</code> in the message text for multi-line reminders.</p>
+<p>Pause reminder delivery for a server with <code>/reminder toggle enabled:false</code>; re-enable with <code>/reminder toggle enabled:true</code>. Reminders remain saved while delivery is disabled.</p>
 <p><em>Permissions</em>: members need <strong>Use Application Commands</strong> to create or remove reminders, and the bot must have <strong>Send Messages</strong> in the target channel.</p>
 </section>
 

--- a/docs/CATCORD_ADMIN_QUICKSTART.html
+++ b/docs/CATCORD_ADMIN_QUICKSTART.html
@@ -77,7 +77,8 @@
 /reminder add name:colony channel:#ops message:"Territory Development\n-Building Power\n-Fortification Power" headline:"Colony Action" interval:1 unit:days
 /reminder add name:launch channel:#ops message:"Launch prep" time:13:00 once:true
 /reminder list
-/reminder remove name:backup</pre>
+/reminder remove name:backup
+/reminder toggle enabled:false</pre>
 </div>
 </section>
 <section class="two">


### PR DESCRIPTION
## Summary
- persist a per-guild reminder enabled flag alongside stored reminder definitions
- stop scheduled reminders from firing when the guild has reminders disabled
- expose `/reminder toggle` to enable or disable deliveries and document the new command

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc8a465a008327bb5085365fd24bfd