### PR TITLE
Update Catcord guides with current features

### DIFF
--- a/docs/CATCORD_ADMIN_GUIDE.html
+++ b/docs/CATCORD_ADMIN_GUIDE.html
@@ -13,6 +13,7 @@
   p.lead { color:var(--muted); margin:0 0 16px; }
   section { background:var(--panel); border:1px solid var(--border); border-radius:12px; padding:16px 18px; margin:14px 0; }
   h2 { font-size:1.2rem; margin:0 0 10px; }
+  h3 { font-size:1.05rem; margin:0.8em 0 0.35em; }
   pre, code { background:#0b1220; color:#d1e7ff; border:1px solid #19223a; border-radius:6px; }
   code { padding:2px 6px; }
   pre { padding:10px 12px; overflow-x:auto; }
@@ -27,65 +28,88 @@
 <section>
 <h2>Configuration</h2>
 <ul>
-<li>Optional guild restriction via <code>GUILD_ID</code> in <code>.env</code></li>
+<li><strong>Tokens:</strong> <code>DISCORD_TOKEN</code> (required), <code>DEEPL_TOKEN</code> and/or <code>OPENAI_TOKEN</code> for translation, optional <code>DEEPL_API_URL</code>, <code>OPENAI_API_URL</code>, <code>OPENAI_MODEL</code>.</li>
+<li><strong>Guild scope:</strong> set <code>GUILD_ID</code> in <code>.env</code> to restrict the bot to a single server during testing.</li>
+<li><strong>Webhook label:</strong> override <code>LANGRELAY_WEBHOOK_NAME</code> to customise the relay webhook name.</li>
+<li><strong>Persistence:</strong> per-guild LangRelay data lives in <code>./data/langrelay/&lt;guild_id&gt;.json</code>; reminders live in <code>./data/reminder/&lt;guild_id&gt;.json</code>.</li>
+<li>Slash commands sync automatically on launch; run the <code>reload</code>/<code>load</code>/<code>unload</code> owner commands to hot-reload cogs.</li>
 </ul>
 </section>
 
 <section>
 <h2>Language Relay</h2>
-<p>Mirror and translate messages between channels using <code>/langrelay</code> commands.</p>
-<h3>Common Commands</h3>
-<pre>/langrelay_group_create &lt;name&gt;
-/langrelay_group_delete &lt;name&gt;
-/langrelay_group_add &lt;name&gt; #channel CODE
-/langrelay_group_remove &lt;name&gt; #channel
+<p>Mirror language channels with webhooks, optional translation (DeepL or OpenAI), reply context, thread mirroring, and mirrored reactions.</p>
+<h3>Group lifecycle</h3>
+<pre>/langrelay_group_create EU
+/langrelay_group_add EU #german DE
+/langrelay_group_add EU #english EN-US
+/langrelay_group_add EU #french FR
 /langrelay_group_list
-/langrelay_provider provider:&lt;deepl|openai&gt;
-/langrelay_replymode state:&lt;on|off&gt;
-/langrelay_thread_mirroring state:&lt;on|off&gt;
-/langrelay_reaction_mirroring state:&lt;on|off&gt;
-/langrelay_status
-/langrelay_power state:&lt;on|off&gt;
-/langrelay_group_power group:&lt;name&gt; state:&lt;on|off&gt;</pre>
-<p>Mappings persist across bot restarts and are stored per guild in <code>./data/langrelay/&lt;guild_id&gt;.json</code>.</p>
-<p><em>Permissions</em>: bot requires <strong>Send Messages</strong>, <strong>Manage Webhooks</strong>, and <strong>Read Message History</strong>.</p>
+/langrelay_group_power group:EU state:off
+/langrelay_group_power group:EU state:on
+/langrelay_group_remove group:EU channel:#french
+/langrelay_group_delete group:EU</pre>
+<p><em>Notes:</em> groups are bidirectional; channel names are stored as keys. Removing the final channel deletes the group automatically.</p>
+<h3>Provider &amp; options</h3>
+<ul>
+<li><code>/langrelay_provider provider:&lt;deepl|openai&gt;</code> – validates keys before switching.</li>
+<li><code>/langrelay_power state:&lt;on|off&gt;</code> – global enable/disable.</li>
+<li><code>/langrelay_replymode state:&lt;on|off&gt;</code> – adds reply context text above mirrored messages.</li>
+<li><code>/langrelay_thread_mirroring state:&lt;on|off&gt;</code> – mirrors threads with matching names.</li>
+<li><code>/langrelay_reaction_mirroring state:&lt;on|off&gt;</code> – copies emoji reactions across mirrored posts.</li>
+</ul>
+<h3>Status &amp; maintenance</h3>
+<ul>
+<li><code>/langrelay_status</code> – shows provider, feature toggles, and every group with their current state (<code>on/off</code>).</li>
+<li><code>/langrelay_group_add</code> and <code>..._remove</code> offer autocomplete for groups and language codes; DeepL targets are fetched hourly when a token is available.</li>
+<li>Webhook permissions required: <strong>Send Messages</strong>, <strong>Manage Webhooks</strong>, <strong>Read Message History</strong>, plus <strong>Create Public Threads</strong> when thread mirroring is enabled.</li>
+</ul>
 </section>
 
 <section>
 <h2>Auto-Translate</h2>
-<p>Enable automatic translation in a channel.</p>
-<h3>Commands</h3>
-<pre>/autotranslate_on target:&lt;code&gt; [source:&lt;code&gt;] [formality:&lt;default|less|more&gt;] [min_chars:&lt;number&gt;]
+<p>Enable per-channel automatic translations without creating relay mappings.</p>
+<pre>/autotranslate_on target:EN-US source:DE formality:more min_chars:8
 /autotranslate_status
 /autotranslate_off</pre>
-<p>Requires translation API key. Per-channel settings are not persistent.</p>
+<ul>
+<li>Supported targets follow DeepL’s codes (with autocomplete). Sources are optional; leave blank for auto-detect.</li>
+<li><code>formality</code> accepts <code>default</code>, <code>less</code>, or <code>more</code> when supported by the target language.</li>
+<li><code>min_chars</code> prevents short confirmations from triggering translations (default 5 characters).</li>
+<li>Replies are posted to the original message; fallback channel messages are used if replying fails due to permissions.</li>
+</ul>
 </section>
 
 <section>
 <h2>Reminders</h2>
-<p>Schedule repeating messages using <code>/reminder</code> commands.</p>
-<h3>Syntax</h3>
-<pre>/reminder add name:&lt;id&gt; channel:&lt;#channel&gt; message:&lt;text&gt; [headline:&lt;title&gt;] [interval:&lt;number&gt; unit:&lt;minutes|hours|days&gt;] [weekday:&lt;day&gt;] [time:&lt;HH:MM&gt;] [once:true]</pre>
-<h3>Examples</h3>
+<p>Schedule repeating or one-time reminders with persistent storage and optional LangRelay mirroring.</p>
+<h3>Create</h3>
+<pre>/reminder add name:backup channel:#ops message:"Run backup" time:02:00
+/reminder add name:reports channel:#ops message:"Weekly metrics" times:"Mon@09:00, Thu@09:00" group:Ops
+/reminder add name:launch channel:#ops message:"Launch prep" interval:1 unit:days once:true</pre>
+<h3>Maintain</h3>
+<pre>/reminder edit name:reports add_times:"Sat@09:00" headline:"Weekly Reports"
+/reminder edit name:backup clear_interval:true
+/reminder remove name:launch
+/reminder list
+/reminder toggle enabled:false</pre>
+<h3>Group tools</h3>
+<pre>/reminder group rename name:Ops new_name:Operations
+/reminder group remove name:Operations delete_reminders:true</pre>
 <ul>
-<li><code>/reminder add name:backup channel:#general message:"Run backup" time:02:00</code></li>
-<li><code>/reminder add name:standup channel:#dev message:"Daily standup" interval:1 unit:days time:09:00</code></li>
-<li><code>/reminder add name:colony channel:#ops message:"Territory Development\n-Building Power\n-Fortification Power" headline:"Colony Action" interval:1 unit:days</code></li>
-<li><code>/reminder add name:launch channel:#ops message:"Launch prep" time:13:00 once:true</code></li>
-<li><code>/reminder remove name:backup</code></li>
-<li><code>/reminder list</code></li>
-<li><code>/reminder toggle enabled:false</code></li>
+<li>Schedules accept either an interval (<code>interval</code> + <code>unit</code>) or explicit times via <code>time</code> / <code>times</code>; mixing both is prevented.</li>
+<li>Use <code>group</code> labels to organise reminders; grouped entries appear together in <code>/reminder list</code> and can be bulk-renamed/removed.</li>
+<li>Reminders pause globally with <code>/reminder toggle enabled:false</code>; stored entries remain intact.</li>
+<li>When a reminder fires in a mapped LangRelay channel, translations are attempted for each linked channel automatically.</li>
 </ul>
-<p>Reminders persist across bot restarts and are stored per guild in <code>./data/reminder/&lt;guild_id&gt;.json</code>. When a time is provided, reminders fire on the minute (UTC). Supplying only a time schedules a daily reminder, and adding <code>once:true</code> creates a one-time reminder that deletes itself after sending. Provide an optional <code>headline</code> to place the reminder inside an embed, and include <code>\n</code> in the message text for multi-line reminders.</p>
-<p>Pause reminder delivery for a server with <code>/reminder toggle enabled:false</code>; re-enable with <code>/reminder toggle enabled:true</code>. Reminders remain saved while delivery is disabled.</p>
-<p><em>Permissions</em>: members need <strong>Use Application Commands</strong> to create or remove reminders, and the bot must have <strong>Send Messages</strong> in the target channel.</p>
 </section>
 
 <section>
-<h2>Utilities</h2>
+<h2>Utilities &amp; Diagnostics</h2>
 <ul>
-<li><code>/translate</code>, <code>/detect</code>, <code>/languages</code></li>
-<li><code>/ping</code>, <code>/about</code></li>
+<li><code>/translate</code>, <code>/detect</code>, <code>/languages</code> – DeepL helpers with autocomplete.</li>
+<li><code>/tping</code> (translation cog health), <code>/ping</code> (latency), <code>/about</code> (bot metadata), <code>/hello</code> (connectivity test).</li>
+<li>Owner-only text commands: <code>!reload cogs.langrelay</code>, <code>!load ...</code>, <code>!unload ...</code>.</li>
 </ul>
 </section>
 

--- a/docs/CATCORD_ADMIN_QUICKSTART.html
+++ b/docs/CATCORD_ADMIN_QUICKSTART.html
@@ -30,6 +30,7 @@
 <ul>
 <li><code>Send Messages</code>, <code>Manage Webhooks</code>, <code>Read Message History</code></li>
 <li>If using threads: <code>Create Public Threads</code></li>
+<li>Optional diagnostics: allow <code>Use Application Commands</code> for staff running slash commands.</li>
 </ul>
 </section>
 <section class="two">
@@ -37,71 +38,75 @@
 <h2>2) Map Channels</h2>
 <pre>/langrelay_group_create EU
 /langrelay_group_add EU #german DE
-/langrelay_group_add EU #english EN
+/langrelay_group_add EU #english EN-US
 /langrelay_group_add EU #french FR
 /langrelay_group_list</pre>
+<p>Use autocomplete for groups and language codes; remove entries with <code>/langrelay_group_remove</code>.</p>
 </div>
 <div>
 <h2>3) Choose Provider</h2>
 <pre>/langrelay_provider provider:deepl
 # or:
 /langrelay_provider provider:openai</pre>
+<p>Bot validates tokens before switching. Default provider favours OpenAI when both keys exist.</p>
 </div>
 </section>
 <section class="two">
 <div>
 <h2>4) Toggle Options</h2>
-<pre><code>/langrelay_replymode state:on
+<pre>/langrelay_replymode state:on
 /langrelay_thread_mirroring state:on
-/langrelay_reaction_mirroring state:on</code></pre>
+/langrelay_reaction_mirroring state:on</pre>
+<p>Leave options off if you do not need reply context, thread mirroring, or reaction sync.</p>
 </div>
 <div>
-<h2>5) Verify</h2>
-<pre><code>/langrelay_status</code></pre><h2>6) Power (Global On/Off)</h2><pre>/langrelay_power state:off
-# later
-/langrelay_power state:on</pre><h2>Group Power</h2><pre>/langrelay_group_power group:EU state:off
-# later
-/langrelay_group_power group:EU state:on</pre>
+<h2>5) Power Controls</h2>
+<pre>/langrelay_power state:on
+/langrelay_group_power group:EU state:on
+/langrelay_status</pre>
+<p>Use group power to pause a single mapping while keeping others online.</p>
 </div>
 </section>
 <section class="two">
 <div>
-<h2>7) Auto-Translate (Optional)</h2>
-<pre>/autotranslate_on target:EN
+<h2>6) Auto-Translate (Optional)</h2>
+<pre>/autotranslate_on target:EN-US source:DE formality:more min_chars:8
 /autotranslate_status
 /autotranslate_off</pre>
+<p>Enable in channels without relay mappings. Keep <code>min_chars</code> low enough for natural replies.</p>
 </div>
 <div>
-<h2>8) Schedule Reminders</h2>
-<pre>/reminder add name:backup channel:#general message:"Run backup" time:02:00
-/reminder add name:colony channel:#ops message:"Territory Development\n-Building Power\n-Fortification Power" headline:"Colony Action" interval:1 unit:days
-/reminder add name:launch channel:#ops message:"Launch prep" time:13:00 once:true
+<h2>7) Schedule Reminders</h2>
+<pre>/reminder add name:backup channel:#ops message:"Run backup" time:02:00
+/reminder add name:reports channel:#ops message:"Weekly metrics" times:"Mon@09:00, Thu@09:00" group:Ops
 /reminder list
-/reminder remove name:backup
 /reminder toggle enabled:false</pre>
+<p>Use <code>/reminder edit</code> for adjustments and <code>/reminder group rename</code>/<code>... remove</code> to manage labelled sets.</p>
 </div>
 </section>
 <section class="two">
 <div>
 <h2>Troubleshooting</h2>
 <ul>
-<li>Nothing mirrored → check mappings &amp; permissions.</li>
-<li>Translation fails → verify keys / provider.</li>
-<li>Threads not mirrored → ensure thread permission.</li>
-<li>Reactions not mirrored → ensure reaction mirroring is enabled.</li>
+<li>Nothing mirrored → check permissions, group power, and <code>/langrelay_status</code>.</li>
+<li>Translation fails → verify provider tokens and API quotas.</li>
+<li>Threads not mirrored → ensure thread option and permissions are active.</li>
+<li>Reactions not mirrored → enable reaction mirroring on both ends.</li>
 </ul>
 </div>
 <div>
 <h2>Useful Utilities</h2>
-<pre><code>/translate  text:&lt;message&gt;
+<pre>/translate  text:&lt;message&gt;
 /detect     text:&lt;message&gt;
 /languages
+/tping
 /ping
-/about</code></pre>
+/about</pre>
+<p>Slash commands answer ephemerally by default. Use <code>/hello</code> for a quick connectivity ping.</p>
 </div>
 </section>
 <section class="note">
-<strong>Tip:</strong> Use consistent channel names (e.g., <code>#german</code>, <code>#english</code>, <code>#french</code>) and map each once.
+<strong>Tip:</strong> Keep consistent channel names (e.g., <code>#german</code>, <code>#english</code>, <code>#french</code>) so you can re-use autocomplete and avoid mapping duplicates.
     </section>
 </div>
 </body>

--- a/docs/CATCORD_USER_MANUAL.html
+++ b/docs/CATCORD_USER_MANUAL.html
@@ -34,16 +34,18 @@ a:hover { text-decoration: underline; }
 
     <section>
       <h2>Overview</h2>
-      <p>Catcord helps people chat across languages. When you write in a language-specific channel (for example, <code>#german</code>), Catcord can mirror your message to other mapped channels (such as <code>#english</code> or <code>#french</code>). Mirrored messages may be automatically translated and are posted via webhooks using your display name and avatar — so they look like you sent them.</p>
+      <p>Catcord helps people chat across languages. When you write in a language-specific channel (for example, <code>#german</code>), Catcord can mirror your message to other mapped channels (such as <code>#english</code> or <code>#french</code>). Mirrored messages may be automatically translated by DeepL or OpenAI and are posted via webhooks using your display name and avatar—so they look like you sent them.</p>
     </section>
 
     <section>
       <h2>How It Works</h2>
       <ul>
-        <li><strong>Channel mappings:</strong> Admins connect language channels (e.g., <code>#german</code> ↔ <code>#english</code> ↔ <code>#french</code>).</li>
+        <li><strong>Channel mappings:</strong> Admins connect language channels (e.g., <code>#german</code> ↔ <code>#english</code> ↔ <code>#french</code>). Each group can be paused independently.</li>
         <li><strong>Invisible posting:</strong> Catcord uses webhooks to post mirrored messages with your name and avatar.</li>
         <li><strong>Translation:</strong> Depending on server settings, messages are translated automatically (DeepL or OpenAI).</li>
+        <li><strong>Auto-translate channels:</strong> Some channels may have <code>/autotranslate_on</code> enabled—messages get an instant reply containing the translation.</li>
         <li><strong>Loop protection:</strong> Messages posted by webhooks aren’t mirrored again.</li>
+        <li><strong>Extras:</strong> Optional reply snippets, thread mirroring, and mirrored emoji reactions can be enabled by admins.</li>
       </ul>
     </section>
 
@@ -54,6 +56,11 @@ a:hover { text-decoration: underline; }
         <li>Write normally in your language channel. If channels are mapped, your message will appear in the other language channels.</li>
         <li>Attachments (images/files) are mirrored with your message when possible.</li>
       </ul>
+      <h3>Auto-translated replies</h3>
+      <ul>
+        <li>In channels with auto-translate, expect a bot reply beneath your message summarising the translation.</li>
+        <li>Keep your text longer than the minimum character threshold (typically 5–10 characters) so translations trigger.</li>
+      </ul>
       <h3>Replies</h3>
       <ul>
         <li>If enabled by admins, mirrored replies include a short translated line indicating what you replied to.</li>
@@ -62,6 +69,10 @@ a:hover { text-decoration: underline; }
       <ul>
         <li>If enabled by admins, messages in a thread are mirrored into threads with the same name in the other channels.</li>
       </ul>
+      <h3>Reactions</h3>
+      <ul>
+        <li>Emoji reactions you add to mirrored messages can be copied to the linked copies when reaction mirroring is on.</li>
+      </ul>
     </section>
 
     <section>
@@ -69,12 +80,34 @@ a:hover { text-decoration: underline; }
       <ul>
         <li>Keep sentences clear and simple for better translations.</li>
         <li>If a translation seems off, try rephrasing and sending again.</li>
-        <li>Mentions may be sanitized to avoid pinging people across different channels.</li>
+        <li>Mentions may be sanitised to avoid pinging people across different channels.</li>
+        <li>Thread names should match across languages to keep mirrored discussions tidy.</li>
       </ul>
     </section>
 
     <section>
-      <h2>Privacy & Transparency</h2>
+      <h2>Slash Commands You Can Use</h2>
+      <ul>
+        <li><code>/translate</code> – translate a custom snippet (results arrive privately by default).</li>
+        <li><code>/detect</code> – detect the language of a message.</li>
+        <li><code>/languages</code> – list supported DeepL language codes.</li>
+        <li><code>/ping</code> – check the bot’s latency.</li>
+        <li><code>/about</code> – see bot information.</li>
+      </ul>
+      <p class="small">Admins may grant additional commands such as <code>/reminder add</code> for scheduling messages. If unsure, ask your moderation team.</p>
+    </section>
+
+    <section>
+      <h2>Reminders</h2>
+      <ul>
+        <li>Servers can schedule reminders with Catcord. When a reminder is configured for your channel, it will appear on the minute (UTC) with the text provided by admins.</li>
+        <li>Reminders may include an embed headline or appear as plain text.</li>
+        <li>If the channel participates in a language relay group, the reminder can be translated and echoed to the paired channels automatically.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Privacy &amp; Transparency</h2>
       <ul>
         <li>Mirrored posts use your display name and avatar via webhooks.</li>
         <li>Catcord does not DM you and does not store your personal messages beyond what is needed to mirror them.</li>
@@ -88,15 +121,7 @@ a:hover { text-decoration: underline; }
         <li><strong>My message isn’t mirrored:</strong> Ask an admin whether your channel is mapped and whether you have permission to post in the target channels.</li>
         <li><strong>Attachment didn’t appear:</strong> Retry with a smaller file; very large attachments can fail.</li>
         <li><strong>Translation looks wrong:</strong> Automatic translation isn’t perfect. Rephrase and resend, or ask an admin which provider is used.</li>
-      </ul>
-    </section>
-
-    <section>
-      <h2>FAQ</h2>
-      <ul>
-        <li><strong>Will I get DMs from Catcord?</strong> No. Catcord posts only in channels the admins configured.</li>
-        <li><strong>Can I turn off mirroring for myself?</strong> Mirroring follows server-wide settings. Ask an admin if you need an exception.</li>
-        <li><strong>Does Catcord ping people?</strong> Mentions may be sanitized in relays to prevent accidental mass-pinging across channels.</li>
+        <li><strong>I see duplicated reminders:</strong> The server might run both relays and reminders; let admins know so they can adjust settings.</li>
       </ul>
     </section>
 


### PR DESCRIPTION
## Summary
- refresh the admin guide with current configuration variables, LangRelay workflows, auto-translate options, and reminder tooling
- expand the admin quickstart to highlight provider selection, group power, updated auto-translate usage, and reminder group management
- update the user manual with info on auto-translate replies, reaction mirroring, available slash commands, and reminder behaviour for members

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd6556163c832796d94111c1f03cc0