### PR TITLE
Improvements

### DIFF
--- a/cogs/reminder.py
+++ b/cogs/reminder.py
@@ -416,6 +416,22 @@ class Reminder(commands.Cog):
             entries.append(cls._parse_single_time(token))
         if not entries:
             raise ValueError("No valid times provided.")
+        missing_weekday_indices: list[int] = []
+        explicit_weekdays: set[int] = set()
+        for index, entry in enumerate(entries):
+            weekday = entry.get("weekday")
+            if weekday is None:
+                missing_weekday_indices.append(index)
+            else:
+                explicit_weekdays.add(int(weekday))
+        if missing_weekday_indices and explicit_weekdays:
+            if len(explicit_weekdays) > 1:
+                raise ValueError(
+                    "When using a shared weekday, all times must use the same weekday."
+                )
+            shared_weekday = next(iter(explicit_weekdays))
+            for index in missing_weekday_indices:
+                entries[index]["weekday"] = shared_weekday
         return entries
 
     @classmethod

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -62,6 +62,15 @@ class ParseTimesArgumentTest(unittest.TestCase):
         entries = Reminder._parse_times_argument("09:15")
         self.assertEqual(entries, [{"weekday": None, "hour": 9, "minute": 15}])
 
+    def test_parse_shared_weekday(self):
+        entries = Reminder._parse_times_argument("Mon@09:00, 10:30")
+        self.assertEqual(entries[0], {"weekday": 0, "hour": 9, "minute": 0})
+        self.assertEqual(entries[1], {"weekday": 0, "hour": 10, "minute": 30})
+
+    def test_parse_conflicting_shared_weekday(self):
+        with self.assertRaises(ValueError):
+            Reminder._parse_times_argument("Mon@09:00, Tue@10:30, 11:45")
+
     def test_invalid_entry(self):
         with self.assertRaises(ValueError):
             Reminder._parse_times_argument("notatime")


### PR DESCRIPTION
Applied shared-weekday logic when parsing reminder times so that unspecified entries inherit a common day and conflicting mixes are rejected. 

