### PR TITLE
Reuse shared HTTP clients for translation cogs

### DIFF
--- a/cogs/autotranslate.py
+++ b/cogs/autotranslate.py
@@ -33,6 +33,7 @@ class AutoTranslate(commands.Cog):
         self.last_action_ts: Dict[int, float] = {}
         self.cooldown_seconds = 0.5
         self._sem_per_channel: Dict[int, asyncio.Semaphore] = {}
+        self._deepl_client = httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=10.0))
 
     async def _deepl_translate(self, text: str, target: str, source: Optional[str], formality: Optional[str]) -> Tuple[str, Optional[str]]:
         if not DEEPL_TOKEN:
@@ -48,24 +49,31 @@ class AutoTranslate(commands.Cog):
         if formality and formality.lower() in {"default","less","more"}:
             data["formality"] = formality.lower()
 
-        timeout = httpx.Timeout(15.0, connect=10.0)
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(TRANSLATE_URL, data=data)
-            if resp.status_code == 429:
-                raise RuntimeError("DeepL: Rate limit erreicht.")
-            if resp.status_code >= 400:
-                try:
-                    detail = resp.json()
-                except Exception:
-                    detail = resp.text
-                raise RuntimeError(f"DeepL-Fehler ({resp.status_code}): {detail}")
+        resp = await self._deepl_client.post(TRANSLATE_URL, data=data)
+        if resp.status_code == 429:
+            raise RuntimeError("DeepL: Rate limit erreicht.")
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json()
+            except Exception:
+                detail = resp.text
+            raise RuntimeError(f"DeepL-Fehler ({resp.status_code}): {detail}")
 
-            payload = resp.json()
-            tr = (payload.get("translations") or [])
-            if not tr:
-                raise RuntimeError("DeepL: Keine Übersetzung erhalten.")
-            out = tr[0]
-            return out.get("text","").strip(), _norm(out.get("detected_source_language"))
+        payload = resp.json()
+        tr = (payload.get("translations") or [])
+        if not tr:
+            raise RuntimeError("DeepL: Keine Übersetzung erhalten.")
+        out = tr[0]
+        return out.get("text","").strip(), _norm(out.get("detected_source_language"))
+
+    def cog_unload(self):
+        client = getattr(self, "_deepl_client", None)
+        if client and not client.is_closed:
+            loop = getattr(self.bot, "loop", None)
+            if loop:
+                loop.create_task(client.aclose())
+            else:
+                asyncio.create_task(client.aclose())
 
     def _get_sem(self, channel_id: int) -> asyncio.Semaphore:
         sem = self._sem_per_channel.get(channel_id)

--- a/cogs/langrelay.py
+++ b/cogs/langrelay.py
@@ -866,7 +866,7 @@ class LangRelay(commands.Cog):
         targets = None
         if provider == "deepl" and DEEPL_TOKEN:
             try:
-                targets = await _deepl_targets()
+                targets = await _deepl_targets(self._deepl_lang_client)
             except Exception:
                 targets = None
         items = suggest_codes(current, targets)

--- a/cogs/langrelay.py
+++ b/cogs/langrelay.py
@@ -41,7 +41,7 @@ WEBHOOK_CACHE_SIZE = 64
 # === Sprachlisten-Cache für DeepL (Targets) ===
 _DEEPL_LANG_CACHE = {"ts": 0.0, "targets": set()}
 
-async def _deepl_targets() -> Set[str]:
+async def _deepl_targets(client: httpx.AsyncClient) -> Set[str]:
     """Gültige DeepL-Target-Sprachen laden (1×/Stunde cachen)."""
     now = time.time()
     if _DEEPL_LANG_CACHE["targets"] and now - _DEEPL_LANG_CACHE["ts"] < 3600:
@@ -52,8 +52,7 @@ async def _deepl_targets() -> Set[str]:
 
     url = f"{DEEPL_API_URL}/languages"
     try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0, connect=5.0)) as client:
-            resp = await client.get(url, params={"type": "target", "auth_key": DEEPL_TOKEN})
+        resp = await client.get(url, params={"type": "target", "auth_key": DEEPL_TOKEN})
         resp.raise_for_status()
         data = resp.json() or []
         targets = {(item.get("language") or "").upper() for item in data if item.get("language")}
@@ -111,6 +110,20 @@ class LangRelay(commands.Cog):
         self._relay_map: Dict[int, Dict[int, int]] = {}
         self._relay_lookup: Dict[int, int] = {}
         self._channel_locks: Dict[int, asyncio.Lock] = {}
+        self._deepl_client = httpx.AsyncClient(timeout=httpx.Timeout(20.0, connect=10.0))
+        self._deepl_lang_client = httpx.AsyncClient(timeout=httpx.Timeout(10.0, connect=5.0))
+        self._openai_client = httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0))
+
+    def cog_unload(self):
+        loop = getattr(self.bot, "loop", None)
+        for client in (getattr(self, "_deepl_client", None),
+                       getattr(self, "_deepl_lang_client", None),
+                       getattr(self, "_openai_client", None)):
+            if client and not client.is_closed:
+                if loop:
+                    loop.create_task(client.aclose())
+                else:
+                    asyncio.create_task(client.aclose())
 
     # -------------------- Persistence --------------------
     def _guild_path(self, guild_id: int) -> Path:
@@ -342,7 +355,7 @@ class LangRelay(commands.Cog):
         tgt = normalize_code(target_lang)
         src = normalize_code(source_lang)
 
-        targets = await _deepl_targets()
+        targets = await _deepl_targets(self._deepl_lang_client)
         if targets:
             tgt = alias_for_provider(tgt or "", targets)
             if tgt not in targets:
@@ -355,8 +368,7 @@ class LangRelay(commands.Cog):
         if src:
             data["source_lang"] = src
 
-        async with httpx.AsyncClient(timeout=httpx.Timeout(20.0, connect=10.0)) as client:
-            resp = await client.post(TRANSLATE_URL, data=data)
+        resp = await self._deepl_client.post(TRANSLATE_URL, data=data)
         if resp.status_code == 400:
             raise RuntimeError(f"DeepL lehnt den Zielcode ab (`{tgt}`).")
         if resp.status_code == 429:
@@ -388,8 +400,9 @@ class LangRelay(commands.Cog):
             "temperature": 0.2,
         }
 
-        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
-            resp = await client.post(f"{OPENAI_API_URL}/chat/completions", headers=headers, json=body)
+        resp = await self._openai_client.post(
+            f"{OPENAI_API_URL}/chat/completions", headers=headers, json=body
+        )
         if resp.status_code >= 400:
             raise RuntimeError(f"OpenAI-Fehler ({resp.status_code}): {resp.text}")
         data = resp.json()

--- a/cogs/translate.py
+++ b/cogs/translate.py
@@ -1,4 +1,5 @@
 # cogs/translate.py
+import asyncio
 import os
 from typing import Optional, Dict, List, Tuple
 from textwrap import wrap
@@ -43,19 +44,24 @@ class Translate(commands.Cog):
         self.target_langs: List[Tuple[str, str]] = FALLBACK_LANGS[:]
         self.source_langs: List[Tuple[str, str]] = []
         self.CODE_TO_LABEL: Dict[str, str] = {c: l for c, l in self.target_langs}
-        self.bot.loop.create_task(self._load_languages_bg())
+        self._http_client = httpx.AsyncClient(timeout=httpx.Timeout(20.0, connect=10.0))
+        self._language_task: Optional[asyncio.Task] = None
+        if hasattr(self.bot, "loop"):
+            self._language_task = self.bot.loop.create_task(self._load_languages_bg())
 
     # ------------------ Language Loading ------------------
     async def _load_languages_bg(self):
         if not DEEPL_TOKEN:
             return
         try:
-            timeout = httpx.Timeout(15.0, connect=10.0)
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                r_t = await client.get(LANG_URL, params={"auth_key": DEEPL_TOKEN, "type": "target"})
-                r_t.raise_for_status()
-                r_s = await client.get(LANG_URL, params={"auth_key": DEEPL_TOKEN, "type": "source"})
-                r_s.raise_for_status()
+            r_t = await self._http_client.get(
+                LANG_URL, params={"auth_key": DEEPL_TOKEN, "type": "target"}
+            )
+            r_t.raise_for_status()
+            r_s = await self._http_client.get(
+                LANG_URL, params={"auth_key": DEEPL_TOKEN, "type": "source"}
+            )
+            r_s.raise_for_status()
 
             def to_list(items):
                 out: List[Tuple[str, str]] = []
@@ -76,6 +82,8 @@ class Translate(commands.Cog):
             self.source_langs = sorted({c: l for c, l in slist}.items())
             self.CODE_TO_LABEL = {c: l for c, l in self.target_langs + self.source_langs}
             print(f"🗺️  DeepL-Sprachen geladen: {len(self.source_langs)} source, {len(self.target_langs)} target")
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             print(f"⚠️  Konnte DeepL-Sprachen nicht laden, nutze Fallback: {e}")
 
@@ -83,18 +91,39 @@ class Translate(commands.Cog):
     async def _deepl_request(self, data: dict) -> dict:
         if not DEEPL_TOKEN:
             raise RuntimeError("DEEPL_TOKEN fehlt (in .env setzen).")
-        timeout = httpx.Timeout(20.0, connect=10.0)
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(TRANSLATE_URL, data=data)
-            if resp.status_code == 429:
-                raise RuntimeError("DeepL: Rate limit erreicht.")
-            if resp.status_code >= 400:
+        resp = await self._http_client.post(TRANSLATE_URL, data=data)
+        if resp.status_code == 429:
+            raise RuntimeError("DeepL: Rate limit erreicht.")
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json()
+            except Exception:
+                detail = resp.text
+            raise RuntimeError(f"DeepL-Fehler ({resp.status_code}): {detail}")
+        return resp.json()
+
+    def cog_unload(self):
+        loop = getattr(self.bot, "loop", None)
+        if self._language_task and not self._language_task.done():
+            self._language_task.cancel()
+
+            async def _await_cancellation(task: asyncio.Task):
                 try:
-                    detail = resp.json()
+                    await task
+                except asyncio.CancelledError:
+                    pass
                 except Exception:
-                    detail = resp.text
-                raise RuntimeError(f"DeepL-Fehler ({resp.status_code}): {detail}")
-            return resp.json()
+                    pass
+
+            if loop:
+                loop.create_task(_await_cancellation(self._language_task))
+            else:
+                asyncio.create_task(_await_cancellation(self._language_task))
+        if getattr(self, "_http_client", None) and not self._http_client.is_closed:
+            if loop:
+                loop.create_task(self._http_client.aclose())
+            else:
+                asyncio.create_task(self._http_client.aclose())
 
     # ------------------ Core: Translate ------------------
     async def deepl_translate(

--- a/tests/test_http_client_cleanup.py
+++ b/tests/test_http_client_cleanup.py
@@ -1,0 +1,83 @@
+import asyncio
+import importlib.util
+import sys
+import types
+import pathlib
+from types import SimpleNamespace
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load_cog(module_name: str):
+    if "cogs" not in sys.modules:
+        pkg = types.ModuleType("cogs")
+        pkg.__path__ = [str(ROOT / "cogs")]
+        sys.modules["cogs"] = pkg
+
+    full_name = f"cogs.{module_name}"
+    path = ROOT / "cogs" / f"{module_name}.py"
+    spec = importlib.util.spec_from_file_location(full_name, path)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "cogs"
+    sys.modules[full_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+class AsyncClientCleanupTest(unittest.IsolatedAsyncioTestCase):
+    async def test_autotranslate_client_closed_on_unload(self):
+        module = _load_cog("autotranslate")
+        AutoTranslate = module.AutoTranslate
+        loop = asyncio.get_running_loop()
+        bot = SimpleNamespace(loop=loop)
+
+        cog = AutoTranslate(bot)
+        self.assertFalse(cog._deepl_client.is_closed)
+
+        cog.cog_unload()
+        await asyncio.sleep(0)
+
+        self.assertTrue(cog._deepl_client.is_closed)
+
+    async def test_translate_client_closed_on_unload(self):
+        module = _load_cog("translate")
+        Translate = module.Translate
+        loop = asyncio.get_running_loop()
+        bot = SimpleNamespace(loop=loop)
+
+        cog = Translate(bot)
+        client = cog._http_client
+        self.assertFalse(client.is_closed)
+
+        cog.cog_unload()
+        await asyncio.sleep(0)
+
+        self.assertTrue(client.is_closed)
+        task = getattr(cog, "_language_task", None)
+        if task is not None:
+            self.assertTrue(task.done())
+
+    async def test_langrelay_clients_closed_on_unload(self):
+        module = _load_cog("langrelay")
+        LangRelay = module.LangRelay
+        loop = asyncio.get_running_loop()
+        bot = SimpleNamespace(loop=loop)
+
+        cog = LangRelay(bot)
+        deepl_client = cog._deepl_client
+        lang_client = cog._deepl_lang_client
+        openai_client = cog._openai_client
+
+        self.assertFalse(deepl_client.is_closed)
+        self.assertFalse(lang_client.is_closed)
+        self.assertFalse(openai_client.is_closed)
+
+        cog.cog_unload()
+        await asyncio.sleep(0)
+
+        self.assertTrue(deepl_client.is_closed)
+        self.assertTrue(lang_client.is_closed)
+        self.assertTrue(openai_client.is_closed)


### PR DESCRIPTION
## Summary
- instantiate shared httpx.AsyncClient instances for the AutoTranslate, LangRelay, and Translate cogs and close them during cog unload
- update translation helpers and background loaders to reuse the shared clients instead of creating new ones
- add tests that assert the shared clients close correctly when the cogs are unloaded

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d837babbe08327bf1f83eeb23af7b6